### PR TITLE
inputにreadonlyフラグを付ける

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -1,6 +1,6 @@
 admin-field-text
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  input.input.w-full(ref='input', type='text', value='{opts.riotValue}')
+  input.input.w-full(ref='input', type='text', value='{opts.riotValue}', readonly='{opts.field.options.readonly}')
 
   style(type='less').
     :scope {
@@ -14,7 +14,7 @@ admin-field-text
 
 admin-field-textarea
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  textarea.input.w-full.lh15(ref='input', rows='{opts.field.rows || 4}') {opts.riotValue}
+  textarea.input.w-full.lh15(ref='input', rows='{opts.field.rows || 4}', readonly='{opts.field.options.readonly}') {opts.riotValue}
 
   style(type='less').
     :scope {
@@ -28,7 +28,7 @@ admin-field-textarea
 
 admin-field-date
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}' readonly='{opts.option.readonly}')
+  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}')
 
   style(type='less').
     :scope {
@@ -226,6 +226,3 @@ admin-field-list
         path: `${this.opts.item.path}/${this.opts.field.key}`,
       });
     });
-
-admin-field-hoge
-  div hoge222ß


### PR DESCRIPTION
- 各PJのadmin側で`options: {readonly: true}`と設定したfieldのみ readonlyを付与する対応
- `admin-field-hoge`はついでに削除しています

## kasobu admin
```js
  fields: {
    slug: {
      key: 'data.slug',
      label: 'スラッグ',
      type: 'text',
      options: {
        readonly: true,
      }
    },
```
![image](https://user-images.githubusercontent.com/48088137/122148675-de4d7800-ce95-11eb-8783-a37372ba2b7d.png)
