### PR TITLE
検索結果の重複を避ける

### DIFF
--- a/tags/admin-module-list.pug
+++ b/tags/admin-module-list.pug
@@ -77,4 +77,4 @@ admin-module-list
 
       // fetch
       this.fetch();
-    }, 100);
+    }, 256);

--- a/tags/admin-module-list.pug
+++ b/tags/admin-module-list.pug
@@ -77,4 +77,4 @@ admin-module-list
 
       // fetch
       this.fetch();
-    }, 256);
+    }, 512);


### PR DESCRIPTION
## 対応内容
- `debouncedFetch`関数の遅延実行時間を伸ばす
- fetch()でitemが取れて来る前にreset()が連続で呼ばれた場合、先に`this.item=[]`の処理が2回走り、その後に`this.items.push(...items)`とい状況を避けるため
- これでほぼ起きなくなります（256msだとfetchできないときに20回に1回くらい起きたので512msとしました）

## alog
https://alog.team/teams/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/ld7fJr8iVpebT5ZWEMHh/notes/GFkBRVKX7D9UE9UbADCT

## スクショ
![image](https://user-images.githubusercontent.com/48088137/123594092-3be4ab80-d82a-11eb-890e-f0ee9da29bbb.png)
