### PR TITLE
dateがreadonlyのとき反応しないようにする

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -84,7 +84,7 @@ admin-field-textarea
 
 admin-field-date
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent pointer-none": opts.field.options.readonly}')
+  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}', tabindex='{opts.field.options.readonly ? -1 : 0}', class='{"bg-whitesmoke border-transparent pointer-none": opts.field.options.readonly}')
 
   style(type='less').
     :scope {

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -84,7 +84,7 @@ admin-field-textarea
 
 admin-field-date
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
+  input.input.w-full(ref='datetimepicker', required='{opts.option.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent pointer-none": opts.field.options.readonly}')
 
   style(type='less').
     :scope {


### PR DESCRIPTION
## 対応内容
`admin-field-date`がreadonlyのときは`.pointer-none`を付ける

## 確認方法
- camp-adminのworksの作成日時をタップしても反応しないことを確認
- `admin.js`内の`templates.fields.created_at`の`readonly:false`にすれば反応することを確認

## スクショ
![image](https://user-images.githubusercontent.com/48088137/123727237-4eafbc80-d8cc-11eb-99af-fbb174b59dd4.png)
