### PR TITLE
リセットしたいときは空文字を送る

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -466,7 +466,8 @@ admin-field-collection
         return values;
       }
       else {
-        return this.getItemValue(this.items[0]);
+        //- リセットしたいときは空文字を送る
+        return this.items[0] ? this.getItemValue(this.items[0]) : '';
       }
     };
 


### PR DESCRIPTION
## 対応内容
- admin-field-collectionの単体選択のときに、削除したいときは空文字を送るよう修正
- バックエンドの関係（golang が `null`と何も送らないを判別できない）で空文字を明示的に送っています

## 確認url
http://localhost:3000/articles/c3838n223akg02l0cke0

## スクショ
![image](https://user-images.githubusercontent.com/48088137/124116712-37c6c100-daaa-11eb-9884-0d4a961ec88c.png)
