### PR TITLE
モーダルの候補検索の遅延実行時間を512msに変更

### DIFF
--- a/tags/admin-modal-collection.pug
+++ b/tags/admin-modal-collection.pug
@@ -27,7 +27,7 @@ admin-modal-collection.f.fh
 
     this.debouncedSyncCandidates = _.debounce((e) => {
       this.syncCandidates();
-    }, 100);
+    }, 512);
 
     this.getItemValue = (item) => {
       return admin.utils.$get(item, this.opts.options.value_key);


### PR DESCRIPTION
## 対応内容
他の検索バー同様に遅延実行時間を`100`→`512`msに変更

## alog
https://alog.team/teams/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/tUzK4lVqnaHVA8P2cOjd/notes/ERs4ylRWw93eLQOEyZVi

## スクショ
![image](https://user-images.githubusercontent.com/48088137/125651435-9c81ed53-0586-4945-a664-a53d0c890bdb.png)
