### PR TITLE
日付を何も入力していない場合、値を0にする

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -106,7 +106,8 @@ admin-field-date
 
     this.getValue = () => {
       var datetime = dayjs(this.refs.datetimepicker.value.valueOf());
-      return +datetime;
+      //- 何も入力していなければNaNになるので値を0にする
+      return +datetime || 0;
     };
 
 // TODO:


### PR DESCRIPTION
## 対応内容
`admin-field-date`で何も入力していなければNaNになっていたので、値を0にする

## 留意点
- `NaN`→ `0`にするという対応方針がそもそも問題無いかという観点でもレビューいただきたいです

## alog
https://alog.team/teams/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/4USlfT03q7grQ8moao1F/notes/EKCf0nE37qcI9RUR7XaN

- kasobu mediaの場合は更新日を消したいという要望があります
- front側でスクショのように対応しているため上記で要件を満たせます
![image](https://user-images.githubusercontent.com/48088137/126123565-347ecef3-578e-4234-8e1c-29319d203785.png)

## スクショ
![image](https://user-images.githubusercontent.com/48088137/126123755-68287d1a-adfb-49c7-83d8-3763156232f1.png)

