### PR TITLE
admin-field-numberを作成

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -84,7 +84,7 @@ admin-field-textarea
 
 admin-field-number
   div.fs11.bold.text-gray.mb8(if='{opts.field.label}') {opts.field.label}
-  input.input.w-full(ref='input', type='number', step='{opts.field.options.step}', min='{opts.field.options.min || 0}', max='{opts.field.options.max}', value='{opts.riotValue}', required='{opts.field.options.required}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
+  input.input.w-full(ref='input', type='number', step='{opts.field.options.step}', min='{opts.field.options.min}', max='{opts.field.options.max}', value='{opts.riotValue}', required='{opts.field.options.required}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
 
   style(type='less').
     :scope {

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -84,7 +84,7 @@ admin-field-textarea
 
 admin-field-number
   div.fs11.bold.text-gray.mb8(if='{opts.field.label}') {opts.field.label}
-  input.input.w-full(ref='input', type='number', step='{opts.field.options.step}', min='{opts.field.options.minimum || 0}', value='{opts.riotValue}', required='{opts.field.options.required}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
+  input.input.w-full(ref='input', type='number', step='{opts.field.options.step}', min='{opts.field.options.min || 0}', max='{opts.field.options.max}', value='{opts.riotValue}', required='{opts.field.options.required}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
 
   style(type='less').
     :scope {

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -82,6 +82,20 @@ admin-field-textarea
       return this.refs.input.value;
     };
 
+admin-field-number
+  div.fs11.bold.text-gray.mb8(if='{opts.field.label}') {opts.field.label}
+  input.input.w-full(ref='input', type='number', step='{opts.field.options.step}', min='{opts.field.options.minimum || 0}', value='{opts.riotValue}', required='{opts.field.options.required}', readonly='{opts.field.options.readonly}', class='{"bg-whitesmoke border-transparent": opts.field.options.readonly}')
+
+  style(type='less').
+    :scope {
+      display: block;
+    }
+
+  script.
+    this.getValue = () => {
+      return Number(this.refs.input.value);
+    };
+
 admin-field-date
   div.fs11.bold.text-gray.mb8 {opts.field.label}
   input.input.w-full(ref='datetimepicker', required='{opts.field.options.required}', placeholder='{opts.field.options.placeholder}', readonly='{opts.field.options.readonly}', tabindex='{opts.field.options.readonly ? -1 : 0}', class='{"bg-whitesmoke border-transparent pointer-none": opts.field.options.readonly}')


### PR DESCRIPTION
## 対応内容
- 数値の入力フォームを作成
- `input type='number'`
- 以下をoptionsで設定できる
  - min
  - step

## 確認方法
[cosmen admin](https://github.com/rabee-inc/cosmen-admin/pull/4) の販売チャネル（価格）で適用しています
