### PR TITLE
admin-field-imageの修正

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -320,7 +320,7 @@ admin-field-image
     //- optionによって削除ボタンを表示 デフォルトはtrue
     this.isDeletable = () => {
       var deletable = true;
-      if (this.opts.field.options.deletable !== undefined) {
+      if (this.opts.field.options && this.opts.field.options.deletable !== undefined) {
         deletable = this.opts.field.options.deletable;
       }
       return deletable && this.url || this.file;

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -208,7 +208,7 @@ admin-field-image
     img.s-full.object-fit-contain.border(if="{url}", src='{url}')
     div.absolute.trbl0.s-full.f.fh.fs26 +
     div.absolute.tn16.rn16.bg-gray_pale.f.fh.circle.s32.border(if='{url || file}', onclick='{delete}')
-      i.material-icons.fs20 delete
+      div.f.fh.s-full.pb4.fs20 ×
 
   div.fs10.mb16(if='{!opts.field.options}') クリック または ドラッグ&ドロップで追加できます
   

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -280,14 +280,23 @@ admin-field-image
     };
 
     this.getValue = async () => {
-      //- 変更していない場合
-      if (!this.file && this.url === this.opts.riotValue) return this.opts.riotValue;
+      //- ファイルが存在しない場合
+      if (!this.file) {
+        //- 変更していない場合
+        if (this.url === this.opts.riotValue) {
+          return this.opts.riotValue;
+        }
 
-      //- アップロード済みの画像から選択した場合
-      if (!this.file && /^http.+/.test(this.url)) return this.url;
+        //- アップロード済みの画像から選択した場合
+        if (/^http.+/.test(this.url)) {
+          return this.url;
+        }
 
-      //- 削除した場合
-      if (!this.file && !this.url) return this.url;
+        //- 削除した場合
+        if (!this.url) {
+          return this.url;
+        }
+      }
 
       let url = await app.admin.utils.uploadFile(this.file);
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -294,7 +294,7 @@ admin-field-image
 
         //- 削除した場合
         if (!this.url) {
-          return this.url;
+          return "";
         }
       }
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -10,7 +10,7 @@ admin-field-text
   script.
     this.getValue = () => {
       var value = this.refs.input.value;
-      if (Array.isArray(opts.riotValue)) {
+      if (Array.isArray(this.opts.riotValue)) {
         return value.split(',').map(s => s.trim());
       }
       else {
@@ -225,7 +225,7 @@ admin-field-image
 
   script.
     this.on('mount', () => {
-      this.url = opts.riotValue;
+      this.url = this.opts.riotValue;
       this.update();
 
       this.input = document.createElement('input');
@@ -281,7 +281,7 @@ admin-field-image
 
     this.getValue = async () => {
       //- 変更していない場合
-      if (!this.file && this.url === opts.riotValue) return opts.riotValue;
+      if (!this.file && this.url === this.opts.riotValue) return this.opts.riotValue;
 
       //- アップロード済みの画像から選択した場合
       if (!this.file && /^http.+/.test(this.url)) return this.url;

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -207,7 +207,7 @@ admin-field-image
   div.relative.f.fh.bg-gray_pale.w-full.h-auto.max-width-500.min-height-200.cursor-pointer.mb4(onclick='{onSelectImage}')
     img.s-full.object-fit-contain.border(if="{url}", src='{url}')
     div.absolute.trbl0.s-full.f.fh.fs26 +
-    div.absolute.tn16.rn16.bg-gray_pale.f.fh.circle.s32.border(if='{url || file}', onclick='{delete}')
+    div.absolute.tn16.rn16.bg-gray_pale.f.fh.circle.s32.border(if='{isDeletable()}', onclick='{delete}')
       div.f.fh.s-full.pb4.fs20 ×
 
   div.fs10.mb16(if='{!opts.field.options}') クリック または ドラッグ&ドロップで追加できます
@@ -315,6 +315,15 @@ admin-field-image
       delete this.file;
       this.url = '';
       this.update();
+    };
+
+    //- optionによって削除ボタンを表示 デフォルトはtrue
+    this.isDeletable = () => {
+      var deletable = true;
+      if (this.opts.field.options.deletable !== undefined) {
+        deletable = this.opts.field.options.deletable;
+      }
+      return deletable && this.url || this.file
     };
 
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -274,7 +274,11 @@ admin-field-image
     };
 
     this.getValue = async () => {
-      if (!this.file) return opts.riotValue;
+      //- 変更していない場合
+      if (!this.file && this.url === opts.riotValue) return opts.riotValue;
+
+      //- アップロード済みの画像から選択した場合
+      if (!this.file && /^http.+/.test(this.url)) return this.url;
 
       let url = await app.admin.utils.uploadFile(this.file);
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -323,7 +323,7 @@ admin-field-image
       if (this.opts.field.options.deletable !== undefined) {
         deletable = this.opts.field.options.deletable;
       }
-      return deletable && this.url || this.file
+      return deletable && this.url || this.file;
     };
 
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -204,9 +204,12 @@ admin-field-switch
 
 admin-field-image
   div.fs11.bold.text-gray.mb8 {opts.field.label}
-  div.bg-gray_pale.relative.w-full.h-auto.max-width-500.min-height-200.cursor-pointer.mb4(onclick='{onSelectImage}')
-    img.s-full.object-fit-contain.border(if="{url || opts.riotValue}", src='{url || opts.riotValue}')
+  div.relative.bg-gray_pale.w-full.h-auto.max-width-500.min-height-200.cursor-pointer.mb4(onclick='{onSelectImage}')
+    img.s-full.object-fit-contain.border(if="{url}", src='{url}')
     div.absolute.trbl0.s-full.f.fh.fs26 +
+    div.absolute.tn16.rn16.bg-gray_pale.f.fh.circle.s32.border(if='{url || file}', onclick='{delete}')
+      i.material-icons.fs20 delete
+
   div.fs10.mb16(if='{!opts.field.options}') クリック または ドラッグ&ドロップで追加できます
   
   style(type='less').
@@ -222,6 +225,9 @@ admin-field-image
 
   script.
     this.on('mount', () => {
+      this.url = opts.riotValue;
+      this.update();
+
       this.input = document.createElement('input');
       this.input.type = 'file';
       this.input.accept = 'image/*';
@@ -280,6 +286,9 @@ admin-field-image
       //- アップロード済みの画像から選択した場合
       if (!this.file && /^http.+/.test(this.url)) return this.url;
 
+      //- 削除した場合
+      if (!this.file && !this.url) return this.url;
+
       let url = await app.admin.utils.uploadFile(this.file);
 
       return url;
@@ -289,6 +298,14 @@ admin-field-image
     this.validateFileImageOnly = (type) => {
       var re = /(^image\/\w*)/;
       return re.test(type);
+    };
+
+    //- 選択中の画像を削除する
+    this.delete = (e) => {
+      e.stopPropagation();
+      delete this.file;
+      this.url = '';
+      this.update();
     };
 
 


### PR DESCRIPTION
## クロスコーディング
- @kasaji-jp 

## 概要
- 画像を選択しても反映されていなかったのを修正
- 画像を削除できる様に修正

## 確認方法
- kasobu-adminでサブモジュールに本ブランチを指定し、記事ページや画像ページで画像選択部分の右上のボタンを押す

## screenshot
![image](https://user-images.githubusercontent.com/45706262/130174695-2ac5d49a-c459-46c6-9ede-04ef0fa658fb.png)
