### PR TITLE
admin-field-dateのformatのデフォ値判定を修正

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -111,7 +111,7 @@ admin-field-date
       $(this.refs.datetimepicker).datetimepicker({});
 
       if (this.opts.riotValue) {
-        var format = opts.field.options.format || 'YYYY/MM/DD HH:mm';
+        var format = opts.field.options && opts.field.options.format || 'YYYY/MM/DD HH:mm';
         this.refs.datetimepicker.value = dayjs(this.opts.riotValue).format(format);
       }
 


### PR DESCRIPTION
- optionsの存在確認が抜けていたので追加しました。
- [このpr](https://github.com/rabee-inc/camp-admin/pull/36)で当prのブランチを指定して、募集のページで遷移を繰り返してもエラーがでなければおkです