### PR TITLE
admin-field-buttonでitemではなくriotValueを参照する様に変更

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -509,7 +509,8 @@ admin-field-button
         onclick({
           tag: this,
           field: this.opts.field,
-          item: this.opts.riotValue,
+          item: this.opts.item,
+          value: this.opts.riotValue,
         });
       }
     };

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -509,7 +509,7 @@ admin-field-button
         onclick({
           tag: this,
           field: this.opts.field,
-          item: this.opts.item,
+          item: this.opts.riotValue,
         });
       }
     };


### PR DESCRIPTION
- https://github.com/rabee-inc/camp-admin/pull/30 の修正に伴う対応
- field-arrayではopts.itemがわたってこないので、他のfieldと同様riotValueを参照する様に変更
- http://localhost:3000/contests/game_bbqvol01/contest_entries/doB6LFdLELV5AFoIEy0B のページでarray型のボタン、通常型のボタン双方で動きに問題なければおkです