### PR TITLE
modal-collectionにfilter機能追加

### DIFF
--- a/tags/admin-modal-collection.pug
+++ b/tags/admin-modal-collection.pug
@@ -12,7 +12,7 @@ admin-modal-collection.f.fh
     :scope {
       background-color: rgba(0, 0, 0, 0.5);
     }
-  
+
   script.
     this.on('mount', () => {
       this.syncCandidates();
@@ -23,6 +23,7 @@ admin-modal-collection.f.fh
       var res = await app.admin.crud.index({
         path: `${this.opts.options.collection}`,
         keyword: this.refs.search.value,
+        filters: this.opts.options.filters,
       });
       this.candidates = res.items;
       this.update();

--- a/tags/admin-modal-collection.pug
+++ b/tags/admin-modal-collection.pug
@@ -20,11 +20,15 @@ admin-modal-collection.f.fh
 
     // 候補一覧を更新
     this.syncCandidates = async () => {
-      var res = await app.admin.crud.index({
+      var data = {
         path: `${this.opts.options.collection}`,
         keyword: this.refs.search.value,
-        filters: this.opts.options.filters,
-      });
+      };
+      if (this.opts.options.filters) {
+        data.filters = this.opts.options.filters;
+      }
+
+      var res = await app.admin.crud.index(data);
       this.candidates = res.items;
       this.update();
     };


### PR DESCRIPTION
## 対応内容
kasobu-adminで下書き状態の記事を関連記事で選択できないようにするため、modal-collectionにfilterオプションを渡してapiリクエストのparamに渡せるよう機能追加しました

[kasobu-admin](https://github.com/rabee-inc/kasobu-admin/pull/25 ) をチェックアウトして確認できます

## alog
https://alog.team/teams/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/4USlfT03q7grQ8moao1F/notes/NmwyeBojrAN33I3VidHN

## 使う側のイメージ

![image](https://user-images.githubusercontent.com/48088137/130884454-011dc3bc-6740-43ba-b5f6-180661a20a90.png)


```js
    // 関連記事
    related_articles: {
      key: 'data.related_article_ids',
      label: '関連記事',
      type: 'array',
      options: {
        field: {
          type: 'collection',
          options: {
            collection: 'articles',
            value_key: 'id',
            label_key: 'data.title',
            filters: {
              status: 'published',
            },
          },
        }
      },
    },
```
