### PR TITLE
aタグを挿入時にテキストが複製されないよう修正

### DIFF
--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -92,16 +92,21 @@ admin-field-textarea
       }
 
       if (text) {
-        this.insertText(text);
+        this.insertText(text, selectedValue);
       }
     };
 
-    this.insertText = (text) => {
+    this.insertText = (text, selectedValue) => {
       let input = this.refs.input;
       let cursorPosition = input.selectionStart;
 
       let before = input.value.substr(0, cursorPosition);
       let after = input.value.substr(cursorPosition);
+
+      //- 選択したテキストが複製されないよう削除
+      if (selectedValue) {
+        after = after.replace(selectedValue, '');
+      }
 
       input.value = before + text + after;
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -92,18 +92,16 @@ admin-field-textarea
       }
 
       if (text) {
-        this.insertText(text, selectedValue);
+        this.insertText(text);
       }
     };
 
-    this.insertText = (text, selectedValue='') => {
+    this.insertText = (text) => {
       let input = this.refs.input;
       let cursorPosition = input.selectionStart;
 
       let before = input.value.substr(0, cursorPosition);
-      //- 選択したテキストの後ろのテキスト
-      let after = input.value.substr(cursorPosition + selectedValue.length);
-
+      let after = input.value.substr(input.selectionEnd);
 
       input.value = before + text + after;
 

--- a/tags/admin-field.pug
+++ b/tags/admin-field.pug
@@ -96,17 +96,14 @@ admin-field-textarea
       }
     };
 
-    this.insertText = (text, selectedValue) => {
+    this.insertText = (text, selectedValue='') => {
       let input = this.refs.input;
       let cursorPosition = input.selectionStart;
 
       let before = input.value.substr(0, cursorPosition);
-      let after = input.value.substr(cursorPosition);
+      //- 選択したテキストの後ろのテキスト
+      let after = input.value.substr(cursorPosition + selectedValue.length);
 
-      //- 選択したテキストが複製されないよう削除
-      if (selectedValue) {
-        after = after.replace(selectedValue, '');
-      }
 
       input.value = before + text + after;
 


### PR DESCRIPTION
## 対応内容
テキストを選択した状態で、記事などのタグツールバーから`aタグ`などを選択すると、閉じタグの後ろにテキストが複製されるのを修正しました

![image.png](https://firebasestorage.googleapis.com/v0/b/alog-rabee-jp.appspot.com/o/users%2FqUfdSZZ1kbhIZGuVhSzDgkabIYb2%2Ffiles%2F1630663148.png?alt=media&token=b86aecd3-c4b9-4a9a-a69e-a4d57bd995e0)

## 確認方法 
- kasobu admin で[このコミット](0c3ae3ece6bab46cad42bb698bc4f8e32c822795)をsubmoduleに紐付け
- 記事内のテキストを選択状態で タグツールバーから `aタグ`などを選択
![image](https://user-images.githubusercontent.com/48088137/132653692-c3a9d128-5151-4a46-ad6e-596fe9b600de.png)
- 選択中のテキストが閉じタグの後ろに複製されないことを確認
![image](https://user-images.githubusercontent.com/48088137/132654047-b5dade45-084d-4310-a1aa-809e88973f4d.png)

##  [alog](https://renew.alog.team/teams/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/tUzK4lVqnaHVA8P2cOjd/notes/aGcIzklSDWlAQKFwLUMM)